### PR TITLE
Add prototype redirects to astro.config.mjs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,9 @@
 // @ts-check
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  redirects: {
+    "/prototypes/draper/": "/prototypes/draper/index.html",
+  },
+});

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   redirects: {
+    "/prototypes/aerospace/": "/prototypes/aerospace/index.html",
     "/prototypes/apollo/": "/prototypes/apollo/index.html",
     "/prototypes/apollo2/": "/prototypes/apollo2/index.html",
     "/prototypes/apollo3/": "/prototypes/apollo3/index.html",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,18 @@ import { defineConfig } from "astro/config";
 // https://astro.build/config
 export default defineConfig({
   redirects: {
+    "/prototypes/apollo/": "/prototypes/apollo/index.html",
+    "/prototypes/apollo2/": "/prototypes/apollo2/index.html",
+    "/prototypes/apollo3/": "/prototypes/apollo3/index.html",
+    "/prototypes/cariq/": "/prototypes/cariq/index.html",
     "/prototypes/draper/": "/prototypes/draper/index.html",
+    "/prototypes/energy-portal/": "/prototypes/energy-portal/index.html",
+    "/prototypes/literacypro-ui/": "/prototypes/literacypro-ui/index.html",
+    "/prototypes/literacypro-ux/": "/prototypes/literacypro-ux/index.html",
+    "/prototypes/sunpower/": "/prototypes/sunpower/index.html",
+    "/prototypes/sunpower-extra/": "/prototypes/sunpower-extra/index.html",
+    "/prototypes/sunpower-poc/": "/prototypes/sunpower-poc/index.html",
+    "/prototypes/texaslawhelp/": "/prototypes/texaslawhelp/index.html",
+    "/prototypes/william-sonoma/": "/prototypes/william-sonoma/index.html",
   },
 });

--- a/src/pages/case-studies/aerospace.astro
+++ b/src/pages/case-studies/aerospace.astro
@@ -63,7 +63,7 @@ import imageInline02 from '../../assets/images/inline__aerospace_metateasers.gif
           <li>
             <strong>In-medium Design Deliverables:</strong> As part of the typical design process I established at Third & Grove, this project included in-medium design deliverables (creative designed and built with HTML, CSS, and JavaScript). Not only did this allow for all stakeholders — no matter technical skills or knowledge — to review creative immediately, it also served as more definitive and granular development materials
             <ul>
-              <li><a href="../prototypes/aerospace" target="_blank">UX/UI Prototypes ➝</a></li>
+              <li><a href="/prototypes/aerospace" target="_blank">UX/UI Prototypes ➝</a></li>
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
Also included formatting fixes.

## Description

Adds redirects to prototypes, so we can reference without the full path.

<!-- Describe your changes in detail. The sections suggested are intended to make -->
<!-- it easy to create a descriptive PR that is easy to review. Change as needed! -->

## Motivation / Context

Otherwise we'd have to pass `/prototypes/draper/index.html` to all prototypes.

Resolves #1.

## Testing Instructions / How This Has Been Tested

1. Run preview via `npm run dev`
2. Go to `case-studies/draper`
3. View link to `<a href="/prototypes/draper" target="_blank">UX/UI Prototypes ➝</a>`
4. Confirm that the link now works

